### PR TITLE
Allow missing JavaDoc

### DIFF
--- a/src/main/resources/spotify_checks.xml
+++ b/src/main/resources/spotify_checks.xml
@@ -196,6 +196,7 @@
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
+            <property name="allowMissingJavadoc" value="true"/>
             <property name="minLineCount" value="2"/>
             <property name="allowedAnnotations" value="Override, Test"/>
             <property name="allowThrowsTagsForSubclasses" value="true"/>


### PR DESCRIPTION
Enforcing JavaDoc on all things `public` makes sense for libraries, but
not for services, imho.
