### PR TITLE
Update import ordering to match Google Style Guide

### DIFF
--- a/src/main/resources/spotify_checks.xml
+++ b/src/main/resources/spotify_checks.xml
@@ -164,11 +164,13 @@
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
-        <module name="CustomImportOrder">
-            <property name="specialImportsRegExp" value="com.spotify"/>
-            <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
-        </module>
+        <module name="ImportOrder">
+            <property name="option" value="top"/>
+            <property name="ordered" value="true"/>
+            <property name="caseSensitive" value="true"/>
+            <property name="separated" value="true"/>
+            <property name="sortStaticImportsAlphabetically" value="true"/>
+        </module> 
         <module name="MethodParamPad"/>
         <module name="OperatorWrap">
             <property name="option" value="NL"/>


### PR DESCRIPTION
Google Java Style Guide (recently updated): https://google.github.io/styleguide/javaguide.html#s3.3.3-import-ordering-and-spacing
ImportOrder documentation for reference: http://checkstyle.sourceforge.net/config_imports.html#ImportOrder

Alternate approach to #4
