### PR TITLE
Change line wrapping mode for assignments.

### DIFF
--- a/src/main/idea/spotify-checkstyle-idea.xml
+++ b/src/main/idea/spotify-checkstyle-idea.xml
@@ -43,7 +43,7 @@
     <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
     <option name="FOR_STATEMENT_WRAP" value="1" />
     <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-    <option name="ASSIGNMENT_WRAP" value="5" />
+    <option name="ASSIGNMENT_WRAP" value="1" />
     <option name="IF_BRACE_FORCE" value="3" />
     <option name="DOWHILE_BRACE_FORCE" value="3" />
     <option name="WHILE_BRACE_FORCE" value="3" />


### PR DESCRIPTION
Switch from "Chop down if long" to "Wrap if long" for assignments. I see no reason for an extra line break between type and variable for a declaration.
