### PR TITLE
Allow to abbreviate integration test as IT

### DIFF
--- a/src/main/resources/spotify_checks.xml
+++ b/src/main/resources/spotify_checks.xml
@@ -161,6 +161,7 @@
         <module name="AbbreviationAsWordInName">
             <property name="ignoreFinal" value="false"/>
             <property name="allowedAbbreviationLength" value="1"/>
+            <property name="allowedAbbreviations" value="IT"/>
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>


### PR DESCRIPTION
The naming convention for integration test classes is to have IT as the
prefix or the suffix. At least that's the default behavior of the maven
failsafe plugin. Of course it's only a problem for the projects with
checkstyle plugin configured to check test classes. But arguably the best
practice is to keep test classes on the same quality level as the rest of
the code, which is why checkstyle should be enabled for test classes too.