### PR TITLE
Relax parameter name checks for non-public methods

### DIFF
--- a/src/main/resources/spotify_checks.xml
+++ b/src/main/resources/spotify_checks.xml
@@ -110,7 +110,16 @@
              value="Member name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="ParameterName">
+            <property name="id" value="ParameterNameNonPublic"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+            <property name="accessModifiers" value="protected, package, private"/>
+            <message key="name.invalidPattern"
+             value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ParameterName">
+            <property name="id" value="ParameterNamePublic"/>
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <property name="accessModifiers" value="public"/>
             <message key="name.invalidPattern"
              value="Parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>


### PR DESCRIPTION
Single-character variable names are sometimes convenient, for example
as dummy parameters in lambdas. This relaxes the rules for non-public
parameters, which includes this case.

This change requires Checkstyle 7.5.