### PR TITLE
Make SuppressionCommentFilter not a child of TreeWalker

### DIFF
--- a/src/main/resources/spotify_checks.xml
+++ b/src/main/resources/spotify_checks.xml
@@ -248,11 +248,11 @@
 
         <!-- Required by SuppressWarningsFilter below -->
         <module name="SuppressWarningsHolder"/>
-
-        <!-- Allow turning checks off in the code -->
-        <!-- See http://checkstyle.sourceforge.net/config.html#SuppressionCommentFilter -->
-        <module name="SuppressionCommentFilter"/>
     </module>
+
+    <!-- Allow turning checks off in the code -->
+    <!-- See http://checkstyle.sourceforge.net/config.html#SuppressionCommentFilter -->
+    <module name="SuppressionCommentFilter"/>
 
     <!-- Allow turning checks off in the code using @SuppressWarnings annotation -->
     <!-- See http://checkstyle.sourceforge.net/config_filters.html#SuppressWarningsFilter -->


### PR DESCRIPTION
undoes https://github.com/spotify/spotify-checkstyle-config/pull/18 since
this seems to break `mvn checkstyle:check` with error

```
Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:2.17:check (default-cli) on project docker-client: Failed during checkstyle configuration: cannot initialize module TreeWalker - TreeWalker is not allowed as a parent of SuppressionCommentFilter
```