### PR TITLE
Disable CommentsIndentation module

### DIFF
--- a/src/main/resources/spotify_checks.xml
+++ b/src/main/resources/spotify_checks.xml
@@ -244,7 +244,6 @@
         <module name="EmptyCatchBlock">
             <property name="exceptionVariableName" value="expected"/>
         </module>
-        <module name="CommentsIndentation"/>
 
         <!-- Required by SuppressWarningsFilter below -->
         <module name="SuppressWarningsHolder"/>


### PR DESCRIPTION
Indented comments often don't make much sense if you're commenting out code.
Especially for commenting out single lines, IntelliJ places the comment marker on the beginning of the line.
It is quite silly to then have to align the comment with the surrounding code (pushing the actual code to the right out of the 'usual' code indentation, unless you invest time in cutting away the whitespace to keep the code aligned).

So much failed compile iterations because of this silly rule.