### PR TITLE
Update XML DTD URL

### DIFF
--- a/src/main/resources/spotify_checks.xml
+++ b/src/main/resources/spotify_checks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
     This is a Spotified version of the google_checks.xml file, from


### PR DESCRIPTION
The DTD URL has changed from puppycrawl.com to checkstyle.org. The file is
no longer available at the old location. Some tools such as the
sbt-checkstyle-plugin need the URL to be set correctly to function properly.
This change has already been made in the upstream google version.

See:
https://github.com/checkstyle/checkstyle/issues/6478