### PR TITLE
Fix for breaking change in checkstyle 8.24

### DIFF
--- a/src/main/resources/spotify_checks.xml
+++ b/src/main/resources/spotify_checks.xml
@@ -32,6 +32,10 @@
     <module name="FileTabCharacter">
         <property name="eachLine" value="true"/>
     </module>
+    <module name="LineLength">
+        <property name="max" value="100"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
 
     <module name="TreeWalker">
         <module name="OuterTypeFilename"/>
@@ -44,10 +48,6 @@
             <property name="allowEscapesForControlCharacters" value="true"/>
             <property name="allowByTailComment" value="true"/>
             <property name="allowNonPrintableEscapes" value="true"/>
-        </module>
-        <module name="LineLength">
-            <property name="max" value="100"/>
-            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
         </module>
         <module name="AvoidStarImport"/>
         <module name="RedundantImport"/>


### PR DESCRIPTION
Checkstyle 8.24 has a breaking change which requires that the LineLength check be
declared outside the TreeWalker module. Here are links to the release notes and
the github issue describing this:

https://checkstyle.sourceforge.io/releasenotes.html#Release_8.24
https://github.com/checkstyle/checkstyle/issues/2116

Note: this change will not work with checkstyle versions < 8.24