### PR TITLE
Track upstream changes

### DIFF
--- a/src/main/resources/spotify_checks.xml
+++ b/src/main/resources/spotify_checks.xml
@@ -228,10 +228,13 @@
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
-            <property name="allowMissingJavadoc" value="true"/>
-            <property name="minLineCount" value="2"/>
             <property name="allowedAnnotations" value="Override, Test"/>
             <property name="allowThrowsTagsForSubclasses" value="true"/>
+        </module>
+        <module name="MissingJavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="minLineCount" value="2"/>
+            <property name="allowedAnnotations" value="Override, Test"/>
         </module>
         <module name="MethodName">
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>


### PR DESCRIPTION
In checkstyle [8.25][1], the deprecated properties allowMissingJavadoc and minLineCount
have been removed from the JavadocMethod check. They are now part of the new check
MissingJavadocMethod. References to the removed properties causes build warnings.
This change mirrors the [update to google_checks.xml][2].

[1]: https://checkstyle.sourceforge.io/releasenotes.html
[2]: https://github.com/checkstyle/checkstyle/blob/5ef0ed088ca8482a08a8c2ec8fd9b5d60df67b26/src/main/resources/google_checks.xml#L250