### PR TITLE
update example in README to use checkstyle 8.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To use it, configure your maven-checkstyle-plugin like so:
        <dependency>
          <groupId>com.puppycrawl.tools</groupId>
          <artifactId>checkstyle</artifactId>
-         <version>8.4</version>
+         <version>8.24</version>
        </dependency>
      </dependencies>
      <configuration>


### PR DESCRIPTION
Since https://github.com/spotify/spotify-checkstyle-config/pull/28 the checkstyle config in this repo is invalid for Checkstyle versions before 8.24, so update the usage example to be compatible with that change.